### PR TITLE
Week 3: Add many-to-many relationship between lessons and topics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ vendor
 .DS_Store
 log
 storage
+.idea/

--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ source "https://rubygems.org"
 gem "rails", ">= 8.0.1"
 # Use `pry` with an `edit` command
 gem 'pry-rails'
+gem 'pry-byebug'
 # The modern asset pipeline for Rails [https://github.com/rails/propshaft]
 gem "propshaft"
 # Use sqlite3 as the database for Active Record

--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,8 @@ source "https://rubygems.org"
 
 # Bundle edge Rails instead: gem "rails", github: "rails/rails", branch: "main"
 gem "rails", ">= 8.0.1"
+# Use `pry` with an `edit` command
+gem 'pry-rails'
 # The modern asset pipeline for Rails [https://github.com/rails/propshaft]
 gem "propshaft"
 # Use sqlite3 as the database for Active Record

--- a/Gemfile
+++ b/Gemfile
@@ -2,9 +2,6 @@ source "https://rubygems.org"
 
 # Bundle edge Rails instead: gem "rails", github: "rails/rails", branch: "main"
 gem "rails", ">= 8.0.1"
-# Use `pry` with an `edit` command
-gem 'pry-rails'
-gem 'pry-byebug'
 # The modern asset pipeline for Rails [https://github.com/rails/propshaft]
 gem "propshaft"
 # Use sqlite3 as the database for Active Record
@@ -31,6 +28,10 @@ gem "thruster", require: false
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri windows ], require: "debug/prelude"
+
+  # Use `pry` with an `edit` command
+  gem 'pry-rails'
+  gem 'pry-byebug'
 
   # Static analysis for security vulnerabilities [https://brakemanscanner.org/]
   gem "brakeman", require: false

--- a/Gemfile
+++ b/Gemfile
@@ -31,7 +31,6 @@ group :development, :test do
 
   # Use `pry` with an `edit` command
   gem 'pry-rails'
-  gem 'pry-byebug'
 
   # Static analysis for security vulnerabilities [https://brakemanscanner.org/]
   gem "brakeman", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -82,6 +82,7 @@ GEM
     brakeman (7.0.0)
       racc
     builder (3.3.0)
+    byebug (12.0.0)
     coderay (1.1.3)
     concurrent-ruby (1.3.4)
     connection_pool (2.4.1)
@@ -183,6 +184,9 @@ GEM
     pry (0.15.2)
       coderay (~> 1.1)
       method_source (~> 1.0)
+    pry-byebug (3.11.0)
+      byebug (~> 12.0)
+      pry (>= 0.13, < 0.16)
     pry-rails (0.3.11)
       pry (>= 0.13.0)
     psych (5.2.2)
@@ -346,6 +350,7 @@ DEPENDENCIES
   jbuilder
   kamal
   propshaft
+  pry-byebug
   pry-rails
   puma (>= 5.0)
   rails (>= 8.0.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -75,14 +75,11 @@ GEM
     ast (2.4.2)
     base64 (0.2.0)
     bcrypt_pbkdf (1.1.1)
-    bcrypt_pbkdf (1.1.1-arm64-darwin)
-    bcrypt_pbkdf (1.1.1-x86_64-darwin)
     benchmark (0.4.0)
     bigdecimal (3.1.9)
     brakeman (7.0.0)
       racc
     builder (3.3.0)
-    byebug (12.0.0)
     coderay (1.1.3)
     concurrent-ruby (1.3.4)
     connection_pool (2.4.1)
@@ -155,21 +152,9 @@ GEM
       net-protocol
     net-ssh (7.3.0)
     nio4r (2.7.4)
-    nokogiri (1.18.1-aarch64-linux-gnu)
-      racc (~> 1.4)
-    nokogiri (1.18.1-aarch64-linux-musl)
-      racc (~> 1.4)
-    nokogiri (1.18.1-arm-linux-gnu)
-      racc (~> 1.4)
-    nokogiri (1.18.1-arm-linux-musl)
-      racc (~> 1.4)
-    nokogiri (1.18.1-arm64-darwin)
-      racc (~> 1.4)
-    nokogiri (1.18.1-x86_64-darwin)
+    nokogiri (1.18.1-x64-mingw-ucrt)
       racc (~> 1.4)
     nokogiri (1.18.1-x86_64-linux-gnu)
-      racc (~> 1.4)
-    nokogiri (1.18.1-x86_64-linux-musl)
       racc (~> 1.4)
     ostruct (0.6.1)
     parallel (1.26.3)
@@ -184,9 +169,6 @@ GEM
     pry (0.15.2)
       coderay (~> 1.1)
       method_source (~> 1.0)
-    pry-byebug (3.11.0)
-      byebug (~> 12.0)
-      pry (>= 0.13, < 0.16)
     pry-rails (0.3.11)
       pry (>= 0.13.0)
     psych (5.2.2)
@@ -297,14 +279,8 @@ GEM
       fugit (~> 1.11.0)
       railties (>= 7.1)
       thor (~> 1.3.1)
-    sqlite3 (2.5.0-aarch64-linux-gnu)
-    sqlite3 (2.5.0-aarch64-linux-musl)
-    sqlite3 (2.5.0-arm-linux-gnu)
-    sqlite3 (2.5.0-arm-linux-musl)
-    sqlite3 (2.5.0-arm64-darwin)
-    sqlite3 (2.5.0-x86_64-darwin)
+    sqlite3 (2.5.0-x64-mingw-ucrt)
     sqlite3 (2.5.0-x86_64-linux-gnu)
-    sqlite3 (2.5.0-x86_64-linux-musl)
     sshkit (1.23.2)
       base64
       net-scp (>= 1.1.2)
@@ -314,13 +290,12 @@ GEM
     stringio (3.1.2)
     thor (1.3.2)
     thruster (0.1.9)
-    thruster (0.1.9-aarch64-linux)
-    thruster (0.1.9-arm64-darwin)
-    thruster (0.1.9-x86_64-darwin)
     thruster (0.1.9-x86_64-linux)
     timeout (0.4.3)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
+    tzinfo-data (1.2025.2)
+      tzinfo (>= 1.0.0)
     unicode-display_width (3.1.3)
       unicode-emoji (~> 4.0, >= 4.0.4)
     unicode-emoji (4.0.4)
@@ -332,16 +307,8 @@ GEM
     zeitwerk (2.7.1)
 
 PLATFORMS
-  aarch64-linux
-  aarch64-linux-gnu
-  aarch64-linux-musl
-  arm-linux-gnu
-  arm-linux-musl
-  arm64-darwin
-  x86_64-darwin
+  x64-mingw-ucrt
   x86_64-linux
-  x86_64-linux-gnu
-  x86_64-linux-musl
 
 DEPENDENCIES
   brakeman
@@ -350,7 +317,6 @@ DEPENDENCIES
   jbuilder
   kamal
   propshaft
-  pry-byebug
   pry-rails
   puma (>= 5.0)
   rails (>= 8.0.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -82,6 +82,7 @@ GEM
     brakeman (7.0.0)
       racc
     builder (3.3.0)
+    coderay (1.1.3)
     concurrent-ruby (1.3.4)
     connection_pool (2.4.1)
     crass (1.0.6)
@@ -135,6 +136,7 @@ GEM
       net-pop
       net-smtp
     marcel (1.0.4)
+    method_source (1.1.0)
     mini_mime (1.1.5)
     minitest (5.25.4)
     net-imap (0.5.4)
@@ -178,6 +180,11 @@ GEM
       activesupport (>= 7.0.0)
       rack
       railties (>= 7.0.0)
+    pry (0.15.2)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+    pry-rails (0.3.11)
+      pry (>= 0.13.0)
     psych (5.2.2)
       date
       stringio
@@ -339,6 +346,7 @@ DEPENDENCIES
   jbuilder
   kamal
   propshaft
+  pry-rails
   puma (>= 5.0)
   rails (>= 8.0.1)
   rspec-rails (~> 7.0.0)

--- a/README_WORKFLOW.md
+++ b/README_WORKFLOW.md
@@ -1,0 +1,35 @@
+Every time you sit down to code, start with this routine:
+```bash
+# Update your local repository with any changes from GitHub
+git fetch origin
+
+# Switch to develop and update it
+git checkout develop
+git pull origin develop
+
+# Create or switch to your feature branch
+git checkout -b feature/week1-ThanhPhongLe  # if creating new
+# or
+git checkout feature/week1-ThanhPhongLe     # if it already exists
+
+# Check your status to see where you are
+git status
+```
+
+If you're collaborating with your classmate and want to see what they're working on, you can fetch their branches without affecting your work:
+
+```bash
+# Update your local repository with all remote branches
+git fetch origin
+
+# List all branches including your classmate's
+git branch -a
+
+# If you see your classmate's feature branch, you can peek at their work
+# without switching to it
+git log origin/feature/week1-YourClassmateName --oneline
+```
+
+Remember, the goal of this workflow is to keep everyone's work organized and prevent conflicts.
+
+

--- a/app/models/lesson.rb
+++ b/app/models/lesson.rb
@@ -1,3 +1,7 @@
 class Lesson < ApplicationRecord
   belongs_to :course
+
+  # Many-to-many relationship with topics
+  has_many :lessons_topics
+  has_many :topics, through: :lessons_topics
 end

--- a/app/models/lessons_topic.rb
+++ b/app/models/lessons_topic.rb
@@ -1,0 +1,7 @@
+class LessonsTopic < ApplicationRecord
+  # This join model creates the many-to-many relationship between lessons and topics
+  # Each record represents one topic being covered by one lesson
+
+  belongs_to :lesson
+  belongs_to :topic
+end

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -1,0 +1,8 @@
+class Topic < ApplicationRecord
+  # This model represents educational topics that can be associated with lessons
+  # Each topic has a unique title like "SQL", "Data Modeling", etc.
+
+  # Many-to-many relationship with lessons
+  has_many :lessons_topics
+  has_many :lessons, through: :lessons_topics
+end

--- a/db/migrate/20250724043055_create_topics.rb
+++ b/db/migrate/20250724043055_create_topics.rb
@@ -1,0 +1,9 @@
+class CreateTopics < ActiveRecord::Migration[8.0]
+  def change
+    create_table :topics do |t|
+      t.string :title, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20250724054221_create_lessons_topics.rb
+++ b/db/migrate/20250724054221_create_lessons_topics.rb
@@ -1,0 +1,9 @@
+class CreateLessonsTopics < ActiveRecord::Migration[8.0]
+  def change
+    create_table :lessons_topics, id: false do |t|
+      t.references :lesson, null: false, foreign_key: true
+      t.references :topic, null: false, foreign_key: true
+    end
+    add_index :lessons_topics, [:lesson_id, :topic_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_01_01_191924) do
+ActiveRecord::Schema[8.0].define(version: 2025_07_24_054221) do
   create_table "coding_classes", force: :cascade do |t|
     t.string "title"
     t.text "description"
@@ -49,6 +49,14 @@ ActiveRecord::Schema[8.0].define(version: 2025_01_01_191924) do
     t.index ["course_id"], name: "index_lessons_on_course_id"
   end
 
+  create_table "lessons_topics", id: false, force: :cascade do |t|
+    t.integer "lesson_id", null: false
+    t.integer "topic_id", null: false
+    t.index ["lesson_id", "topic_id"], name: "index_lessons_topics_on_lesson_id_and_topic_id", unique: true
+    t.index ["lesson_id"], name: "index_lessons_topics_on_lesson_id"
+    t.index ["topic_id"], name: "index_lessons_topics_on_topic_id"
+  end
+
   create_table "mentor_enrollment_assignments", force: :cascade do |t|
     t.integer "mentor_id", null: false
     t.integer "enrollment_id", null: false
@@ -75,6 +83,12 @@ ActiveRecord::Schema[8.0].define(version: 2025_01_01_191924) do
     t.datetime "updated_at", null: false
   end
 
+  create_table "topics", force: :cascade do |t|
+    t.string "title", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
   create_table "trimesters", force: :cascade do |t|
     t.string "year"
     t.string "term"
@@ -90,6 +104,8 @@ ActiveRecord::Schema[8.0].define(version: 2025_01_01_191924) do
   add_foreign_key "enrollments", "courses"
   add_foreign_key "enrollments", "students"
   add_foreign_key "lessons", "courses"
+  add_foreign_key "lessons_topics", "lessons"
+  add_foreign_key "lessons_topics", "topics"
   add_foreign_key "mentor_enrollment_assignments", "enrollments"
   add_foreign_key "mentor_enrollment_assignments", "mentors"
 end

--- a/lesson-01-assignment
+++ b/lesson-01-assignment
@@ -1,0 +1,51 @@
+Question 1
+Finish Task 1: Collect emails for students in the current Intro course
+
+# Assuming the necessary models and associations are set up correctly
+# and that the database contains the relevant data.
+
+# This query retrieves students enrolled in the "Intro to Programming" course
+# during the Spring 2025 trimester, selecting their IDs and emails.
+# It uses joins to connect the Student model with Enrollments, Courses,
+# CodingClasses, and Trimesters, filtering by the specific course title and trimester details.
+Student.joins(enrollments: { course: [:coding_class, :trimester] })
+       .where(coding_classes: { title: "Intro to Programming" },
+              trimesters: { term: "Spring", year: "2025" })
+       .distinct           # Prevents duplicate students
+       .reorder(nil)       # Removes any default ordering
+       .limit(2)
+       .pluck(:id, :email)
+       .each { |id, email| puts "#{id}, #{email}" }
+
+Question 2
+Task 2: Email all mentors who have not assigned a final grade
+
+# Assuming the Mentor, MentorEnrollmentAssignment, Enrollment, Course,
+# CodingClass, and Trimester models are set up correctly.
+# This query retrieves mentors who have not assigned a final grade
+# for students in the "Intro to Programming" course during the Spring 2025 trimester.
+# It uses joins to connect the MentorEnrollmentAssignment with Enrollment,
+# filtering by course ID and checking for null final grades.
+
+# First, we need to find the course based on the given criteria.
+# This query retrieves the course object for "Intro to Programming" in Spring 2025.
+
+course = Course.joins(:coding_class, :trimester)
+               .where(coding_classes: { title: "Intro to Programming" })
+               .where(trimesters: { term: "Spring", year: "2025" })
+               .first
+
+# Now we can find mentors who have not assigned a final grade for this course.
+# We use MentorEnrollmentAssignment to find the relevant mentor IDs,
+# then retrieve their emails.
+# Note: Ensure that MentorEnrollmentAssignment is correctly associated with Enrollment and Mentor.
+
+Mentor.where(
+  id: MentorEnrollmentAssignment
+    .joins(:enrollment)
+    .where(enrollments: { course_id: course.id, final_grade: nil })
+    .distinct
+    .pluck(:mentor_id)
+).limit(2)
+.pluck(:id, :email)
+.each { |id, email| puts "#{id}, #{email}" }

--- a/lesson-02-assignment
+++ b/lesson-02-assignment
@@ -1,0 +1,39 @@
+# Lesson 02 Assignment
+
+# 1. Create (or reuse) the Spring 2026 Trimester
+spring_2026 = Trimester.find_or_create_by(
+  term: 'Spring',
+  year: 2026
+) do |t|
+  t.application_deadline = Date.new(2026,1,3)
+  t.start_date          = Date.new(2026,1,10)
+  t.end_date            = Date.new(2026,4,30)
+end
+spring_2026.persisted?  # => true
+
+# 2. Confirm no Course records exist yet
+Course.where(trimester: spring_2026).pluck(:coding_class_id)
+# => []
+
+# 3. Test creating one Course (should persist)
+first_cc = CodingClass.first
+tc = Course.find_or_create_by(coding_class: first_cc, trimester: spring_2026)
+[tc.persisted?, tc.errors.full_messages]  # => [true, []]
+
+# 4. Create Course records for all CodingClasses without duplicates
+CodingClass.all.each do |cc|
+  course = Course.find_or_create_by(coding_class: cc, trimester: spring_2026)
+  action = course.persisted? && course.created_at == course.updated_at ? 'Created' : 'Found existing'
+  puts "#{action} course for CodingClass ##{cc.id} – #{cc.title}"
+end
+
+# 🎮 Console output example:
+# Created course for CodingClass #1 – Intro to Programming
+# Created course for CodingClass #2 – React
+# Created course for CodingClass #3 – NodeJS
+# Created course for CodingClass #4 – Ruby on Rails
+# Created course for CodingClass #5 – Python
+
+# 5. Verify final set of Course records
+Course.where(trimester: spring_2026).pluck(:coding_class_id)
+# => [1, 2, 3, 4, 5]

--- a/lesson-03-assignment
+++ b/lesson-03-assignment
@@ -1,0 +1,75 @@
+# Lesson 3 Assignment: Many-to-Many Relationship Implementation
+
+## 1. What tables do you need to add? Decide on table names and their associations to each other and any existing tables/models.
+
+We need to add two tables:
+- `topics` - Stores the educational topics (SQL, CSS, JavaScript, etc.)
+- `lessons_topics` - Join table that creates the many-to-many relationship between lessons and topics
+
+The associations work as follows:
+- A lesson has many topics through lessons_topics
+- A topic has many lessons through lessons_topics
+- The lessons_topics table belongs to both lesson and topic
+
+## 2. What columns are necessary for the associations you decided on?
+
+For the `topics` table:
+- `id` (primary key, automatically created by Rails)
+
+For the `lessons_topics` join table:
+- `lesson_id` (foreign key referencing lessons.id)
+- `topic_id` (foreign key referencing topics.id)
+- No `id` column needed (we use `id: false` in the migration)
+
+## 3. What other columns (if any) need to be included on the tables? What other data needs to be stored?
+
+For the `topics` table:
+- `title` (string, not null) - Stores the topic name like "SQL", "JavaScript", etc.
+- `created_at` and `updated_at` (timestamps) - Automatically added by Rails
+
+For the `lessons_topics` join table:
+- No additional columns needed for the basic many-to-many relationship
+- We chose not to include timestamps as they're not necessary for a simple join table
+
+## 4. Write out each table's name and column names with data types.
+
+**topics table:**
+- id: integer (primary key, auto-increment)
+- title: string (varchar 255), not null
+- created_at: datetime, not null
+- updated_at: datetime, not null
+
+**lessons_topics table:**
+- lesson_id: integer, not null, foreign key
+- topic_id: integer, not null, foreign key
+- Composite unique index on (lesson_id, topic_id) to prevent duplicates
+- Individual indexes on both foreign keys for query performance
+
+## 5. Generator commands used:
+
+First migration (topics table):
+bin/rails generate migration CreateTopics
+
+Second migration (join table):
+bin/rails generate migration CreateLessonsTopics
+
+## Implementation Notes:
+
+1. We used `t.references` in the join table migration, which automatically creates indexes on the foreign keys.
+
+2. We added a composite unique index to prevent the same topic from being associated with the same lesson multiple times.
+
+3. The join table uses `id: false` because the combination of lesson_id and topic_id serves as a natural composite key.
+
+4. We created a LessonsTopic model (following Rails naming conventions) to represent the join relationship, even though Rails can work without it. This gives us flexibility to add validations or methods later.
+
+5. We updated both the Lesson and Topic models with the appropriate has_many associations to complete the bidirectional many-to-many relationship.
+
+## Testing Results:
+
+Successfully created associations between lessons and topics in the Rails console, demonstrating:
+- Adding single topics to lessons
+- Adding multiple topics at once
+- Querying lessons by topic
+- Querying topics by lesson
+- Counting associations


### PR DESCRIPTION
## Summary
This PR implements the Week 3 assignment by adding a many-to-many relationship between lessons and topics.

## Changes
1. **Added Topics model** - Allows categorizing lessons by topic
2. **Created lessons_topics join table** - Implements many-to-many relationship
3. **Updated Lesson model** - Added has_and_belongs_to_many :topics association
4. **Added migrations** - For topics table and lessons_topics join table
5. **Updated schema.rb** - Reflects new database structure
6. **Added lesson-03-assignment documentation** - Complete assignment answers

## Context
This work was originally in PR #54 which was closed without merging. This PR ensures the Week 3 assignment is properly included in the main branch.

## Database Changes
- New `topics` table with title field
- New `lessons_topics` join table with composite unique index
- Foreign key constraints properly set up